### PR TITLE
Use HCRT instead of LRMI resource type vocab

### DIFF
--- a/draft/examples/invalid/learningResourceType.json
+++ b/draft/examples/invalid/learningResourceType.json
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@vocab": "http://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "prefLabel": "skos:prefLabel",
+    "inScheme": "skos:inScheme",
+    "Concept": "skos:Concept"
+  },
+  "name": "Beispielkurs",
+  "id": "https://example.org/oer",
+  "type": "Course",
+  "learningResourceType": {
+    "id": "http://purl.org/dcx/lrmi-vocabs/learningResourceType/course"
+  }
+}

--- a/draft/examples/valid/learningResourceType.json
+++ b/draft/examples/valid/learningResourceType.json
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@vocab": "http://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "prefLabel": "skos:prefLabel",
+    "inScheme": "skos:inScheme",
+    "Concept": "skos:Concept"
+  },
+  "name": "Beispielkurs",
+  "id": "https://example.org/oer",
+  "type": "Course",
+  "learningResourceType": {
+    "id": "https://w3id.org/kim/hcrt/course"
+  }
+}

--- a/draft/schemas/schema.json
+++ b/draft/schemas/schema.json
@@ -382,12 +382,6 @@
     "learningResourceType": {
       "title": "Learning Resource Type",
       "type": "object",
-      "_widget": {
-        "type": "SkohubLookup",
-        "options": {
-          "url": "https://skohub.io/acka47/lrmi-resource-types/heads/master/purl.org/dcx/lrmi-vocabs/learningResourceType/"
-        }
-      },
       "properties": {
         "type": {
           "type": "string",
@@ -397,7 +391,8 @@
         },
         "id": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "pattern": "^https:\/\/w3id.org\/kim\/hcrt\/.*"
         },
         "inScheme": {
           "type": "object",
@@ -405,12 +400,16 @@
             "id": {
               "type": "string",
               "enum": [
-                "http://purl.org/dcx/lrmi-vocabs/learningResourceType/"
+                "https://w3id.org/kim/hcrt/scheme"
               ]
             }
           }
         }
-      }
+      },
+      "required": [
+        "id"
+      ],
+      "_widget": "SkohubLookup"
     },
     "audience": {
       "title": "Intended Audience",


### PR DESCRIPTION
As discussed in yesterday's meeting. This PR updates the schema and tests.

One question to think about in this context: Currently, we only allow one value for `learningResourceType`. Should we rather allow multiple values?