### PR TITLE
Expect object array for `isBasedOn`

### DIFF
--- a/draft/examples/invalid/isBasedOn.json
+++ b/draft/examples/invalid/isBasedOn.json
@@ -1,0 +1,64 @@
+{
+  "@context": [
+    "https://w3id.org/kim/lrmi-profile/draft/context.jsonld",
+    {
+      "@language": "de"
+    }
+  ],
+  "name": "Beispielressource",
+  "id": "https://example.org/oer",
+  "mainEntityOfPage": [
+    {
+      "id": "https://example.org/oer-description.html",
+      "type": "Text",
+      "provider": {
+        "id": "https://oerworldmap.org/resource/urn:uuid:4062c64d-b0ac-4941-95c2-8116f137326d",
+        "name": "ZOERR"
+      },
+      "dateCreated": "2020-01-01",
+      "dateModified": "2020-02-02"
+    }
+  ],
+  "image": "https://example.org/oer/image.png",
+  "type": [
+    "LearningResource"
+  ],
+  "creator": [
+    {
+      "name": "HansD",
+      "type": "Person"
+    }
+  ],
+  "description": "Eine OER",
+  "about": [
+    {
+      "id": "https://w3id.org/kim/hochschulfaechersystematik/n059"
+    }
+  ],
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+  "dateCreated": "2019-07-03",
+  "inLanguage": "fr",
+  "publisher": [
+    {
+      "type": "Organization",
+      "name": "Tutory",
+      "id": "https://www.tutory.de"
+    }
+  ],
+  "audience": [
+    {
+      "id": "http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/student"
+    }
+  ],
+  "isBasedOn": {
+    "id": "https://example.org/remixed-resource.html",
+    "type": "LearningResource",
+    "creator": [
+      {
+        "name": "Skye Blue",
+        "type": "Person"
+      }
+    ],
+    "license": "https://creativecommons.org/licenses/by/4.0/"
+  }
+}

--- a/draft/examples/valid/isBasedOn.json
+++ b/draft/examples/valid/isBasedOn.json
@@ -1,0 +1,67 @@
+{
+    "@context": [
+        "https://w3id.org/kim/lrmi-profile/draft/context.jsonld",
+        {
+            "@language": "de"
+        }
+    ],
+    "name": "Beispielressource",
+    "id": "https://example.org/oer",
+    "mainEntityOfPage": [
+        {
+            "id": "https://example.org/oer-description.html",
+            "type": "Text",
+            "provider": {
+                "id": "https://oerworldmap.org/resource/urn:uuid:4062c64d-b0ac-4941-95c2-8116f137326d",
+                "name": "ZOERR"
+            },
+            "dateCreated": "2020-01-01",
+            "dateModified": "2020-02-02"
+        }
+    ],
+    "image": "https://example.org/oer/image.png",
+    "type": [
+        "LearningResource"
+    ],
+    "creator": [
+        {
+            "name": "HansD",
+            "type": "Person"
+        }
+    ],
+    "description": "Eine OER",
+    "about": [
+        {
+            "id": "https://w3id.org/kim/hochschulfaechersystematik/n059"
+        }
+    ],
+    "license": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+    "dateCreated": "2019-07-03",
+    "inLanguage": "fr",
+    "publisher": [
+        {
+            "type": "Organization",
+            "name": "Tutory",
+            "id": "https://www.tutory.de"
+        }
+    ],
+    "audience": [
+        {
+            "id": "http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/student"
+        }
+    ],
+    "isBasedOn": [
+        {
+            "id": "https://example.org/remixed-resource.html",
+            "type": "LearningResource",
+            "name": "Remix me",
+            "creator": [
+                {
+                    "name": "Skye Blue",
+                    "type": "Person"
+                }
+            ],
+            "license": "https://creativecommons.org/licenses/by/4.0/"
+        }
+    ]
+}

--- a/draft/schemas/isBasedOn.json
+++ b/draft/schemas/isBasedOn.json
@@ -5,10 +5,40 @@
     "description": "Resources the described learning resources derived from.",
     "type": "array",
     "items": {
-      "type": "string",
-      "format": "uri",
-      "_display": {
-        "placeholder": "The URL of a resource this OER is based on"
-      }
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "CreativeWork",
+            "LearningResource"
+          ]
+        },
+        "id": {
+          "title": "URL",
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string",
+          "_display": {
+            "placeholder": "The title of the resource"
+          }
+        },
+        "creator": {
+          "$ref": "https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/creator.json"
+        },
+        "license": {
+          "$ref": "https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/license.json"
+        },
+        "provider": {
+          "$ref": "https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/provider.json"
+        }
+      },
+      "required": [
+        "name"
+      ]
     }
   }

--- a/draft/schemas/isBasedOn.json
+++ b/draft/schemas/isBasedOn.json
@@ -9,11 +9,7 @@
       "properties": {
         "type": {
           "title": "Type",
-          "type": "string",
-          "enum": [
-            "CreativeWork",
-            "LearningResource"
-          ]
+          "type": "string"
         },
         "id": {
           "title": "URL",

--- a/draft/schemas/mainEntityOfPage.json
+++ b/draft/schemas/mainEntityOfPage.json
@@ -19,27 +19,7 @@
           "type": "string"
         },
         "provider": {
-          "title": "Metadata provider",
-          "description": "Quelle, von der die strukturierte Beschreibung (=Metadaten) zu dieser Ressource zur Verfügung gestellt werden.",
-          "type": "object",
-          "properties": {
-            "id": {
-              "title": "URI für den Provider",
-              "type": "string",
-              "format": "uri"
-            },
-            "type": {
-              "title": "Typ",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "id"
-          ]
+          "$ref": "https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/provider.json"
         },
         "dateCreated": {
           "$ref": "https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/dateCreated.json"

--- a/draft/schemas/provider.json
+++ b/draft/schemas/provider.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/provider.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Provider",
+    "description": "Quelle, von der eine Bildungsressource oder deren Metadaten zur Verfügung gestellt werden.",
+    "type": "object",
+    "properties": {
+        "id": {
+            "title": "URI für den Provider",
+            "type": "string",
+            "format": "uri"
+        },
+        "type": {
+            "title": "Typ",
+            "type": "string"
+        },
+        "name": {
+            "title": "Name",
+            "type": "string"
+        }
+    },
+    "required": [
+        "id"
+    ]
+}


### PR DESCRIPTION
Resolves #35. Der PR passt das `isBasedOn`-Schema an und ergänzt Test-Dateien. Außerdem ergänzt er ein separates `provider`-Schema, das in den zwei Schemas `mainEntityOfPage` und `isBasedOn` referenziert wird.

@lechten, ich habe dich mal zu der DINI AG KIM GitHub-Organisation eingeladen. Wenn du Interesse hast, dann nimm gerne die Einladung an und ich ergänze dich als Reviewer zu diesem PR. Du kannst das ja gerne auf einer RDF-Ebene betrachten und schauen, ob es für dich prinzipiell passt, auch wenn du es mit RDFa implementierst.