### PR TITLE
Consistent use of English titles in schema

### DIFF
--- a/draft/schemas/provider.json
+++ b/draft/schemas/provider.json
@@ -6,12 +6,12 @@
     "type": "object",
     "properties": {
         "id": {
-            "title": "URI für den Provider",
+            "title": "URL",
             "type": "string",
             "format": "uri"
         },
         "type": {
-            "title": "Typ",
+            "title": "Type",
             "type": "string"
         },
         "name": {


### PR DESCRIPTION
...and URL instead of URI. (I noticed the incosistency in SkoHub Editor.)