### PR TITLE
Fix `isBasedOn` in HTML

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -556,7 +556,7 @@ Verweis auf andere Ressource, von der die beschriebene Ressource ein Derivat ist
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd>`array[string (URI)]`</dd>
+<dd>`array[object]`</dd>
 <dt>Validierung</dt>
 <dd><a href="https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/isBasedOn.json">JSON Schema</a></dd>
 </dl>


### PR DESCRIPTION
...to indicate object array (instead if string (URI) array).