### PR TITLE
Display learningResourceType in SkoHub Editor

### DIFF
--- a/draft/schemas/learningResourceType.json
+++ b/draft/schemas/learningResourceType.json
@@ -4,9 +4,6 @@
   "title": "Learning Resource Type",
   "description": "The learning resource type of the resouce, taken from the controlled HCRT list.",
   "type": "array",
-  "_display": {
-    "className": "hidden"
-  },
   "items": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
see #74. Es hat noch eine weitere Person danach gefragt, so dass ich das hier ergänzew, ehe wir das Profil-Schema vom Editor-Schema separieren (#61).