### PR TITLE
fix the example links by assigning distinct ids

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -694,14 +694,14 @@ Als Kernbestandteil dieser Spezifikation wurde ein [[?JSON Schema]] entwickelt. 
 <section id="examples" class="informative">
 <h2>Beispiele</h2>
 
-<section id="full-example">
+<section id="full-example-higher-education">
 <h2>Beispiele aus dem Bereich Hochschule</h2>
 <pre class="example" title="Beschreibung eines Kurses" data-include="examples/valid/highered-course.json" data-include-format="text"></pre>
 <pre class="example" title="Beschreibung der Präsentation einer Kurseinheit" data-include="examples/valid/highered-course-part.json" data-include-format="text"></pre>
 <pre class="example" title="Beschreibung einer in eine Präsentation eingebetteten Grafik" data-include="examples/valid/highered-figure.json" data-include-format="text"></pre>
 </section>
 
-<section id="full-example">
+<section id="full-example-school">
 <h2>Beispiele aus dem Bereich Schule</h2>
 <pre class="example" title="Beschreibung eines Arbeitsblattes für das Schulfach Französisch" data-include="examples/valid/tutoryExample.json" data-include-format="text"></pre>
 </section>


### PR DESCRIPTION
Habe zwei distinkte IDs für die Beispiele angegeben, damit sie richtig verlinkt werden.

Fixes #103 